### PR TITLE
Added installdesktop plugin

### DIFF
--- a/installdesktop/README.md
+++ b/installdesktop/README.md
@@ -1,0 +1,33 @@
+# linuxdeploy-plugin-installdesktop
+
+This plugin provides an --install-desktop switch to be parsed for an AppImage.  If present, the APP.desktop and APP.png/svg are installed into either /usr/share or ~/.local/share so that the application may be found through the start menu / menu system on a linux platform.
+
+The plugin assumes that there is only one .desktop and only one png/svg file in the root folder of the AppDir.
+
+**:warning: This plugin is experimental and has not been tried with several applications. :warning:**
+
+## Usage
+
+```bash
+# get linuxdeploy and linuxdeploy-plugin-installdesktop
+
+> wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+> wget -c "https://raw.githubusercontent.com/linuxdeploy/misc-plugins/master/installdesktop/linuxdeploy-plugin-installdesktop.sh"
+
+# first option: install your app into your AppDir via `make install` etc.
+# second option: bundle your app's main executables manually
+# see https://docs.appimage.org/packaging-guide/from-source/native-binaries.html for more information
+> [...]
+
+# call through linuxdeploy
+> ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin installdesktop --output appimage --icon-file mypackage.png --desktop-file mypackage.desktop
+```
+## Using
+
+Once packaged, launch the application as follows (to install in the user's folders)
+
+  appimage.AppImage --install-desktop
+
+or (to install in the system folders)
+
+  sudo appimage.AppImage --install-desktop

--- a/installdesktop/linuxdeploy-plugin-installdesktop
+++ b/installdesktop/linuxdeploy-plugin-installdesktop
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# linuxdeploy-plugin-installdesktop.sh
+#
+# Linuxdeploy plugin to add an --install-menu / --install-desktop
+# option to AppImage files which when run, install a desktop and 
+# icon file into the desktop menu infrastructure.
+# When the AppImage file is run as root, the menu files are installed
+# in /usr/share.  Otherwise, they are stored in the user's .config/share
+# folder.
+#
+
+# exit whenever a command called in this script fails
+set -e
+
+APPDIR=""
+HOOKFILE="linuxdeploy-plugin-installdesktop-hook.sh"
+
+show_usage() {
+    echo "Usage: bash $0 --appdir <AppDir>"
+}
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        --plugin-api-version)
+            echo "0"
+            exit 0
+            ;;
+        --appdir)
+            APPDIR="$2"
+            shift
+            shift
+            ;;
+        *)
+            echo "Invalid argument: $1"
+            echo
+            show_usage
+            exit 2
+    esac
+done
+
+if [ -z "${APPDIR}" ]; then
+	show_usage
+	exit 2
+fi
+
+#
+# DEFINITION OF APPHOOK SCRIPT
+#
+
+set -x
+mkdir -p "$APPDIR/apprun-hooks"
+cat > "$APPDIR/apprun-hooks/$HOOKFILE" <<\EOF
+#!/bin/bash
+#
+# installdesktop`
+#
+
+if [ "$1" == "--help" ]; then
+	echo "${APPIMAGE} --install-desktop    - Installs desktop menu files (in /usr/share if run as root)"
+fi
+
+if [ "$1" == "--install-menu" ] || [ "$1" == "--install-desktop" ]; then
+
+	if [ -z "${APPIMAGE}" ]; then
+		echo "APPIMAGE variable not set"
+		exit
+	fi
+
+	if [ -z "${APPDIR}" ]; then
+		echo "APPDIR variable not set"
+		exit
+	fi
+
+	if [ -z "${HOME}" ]; then
+		echo "HOME variable not set"
+		exit
+	fi
+
+	WHOAMI=`whoami`
+
+	if [ "${WHOAMI}" == "root" ]; then
+		TARGET="/usr/share"
+	else
+		TARGET="${HOME}/.local/share"
+	fi
+
+	DESKTOP=${APPDIR}/*.desktop
+
+	if [ ! -f ${DESKTOP} ]; then
+		echo ".desktop file expected in ${APPDIR}"
+		exit
+	fi
+
+        if [ -f ${APPDIR}/*.png ];  then
+                ICON=${APPDIR}/*.png
+        fi
+        if [ -f ${APPDIR}/*.svg ]; then
+                ICON=${APPDIR}/*.svg
+        fi
+        if [ -z ${ICON} ]; then
+                echo "png or svg icon not found in ${APPDIR}"
+                exit
+        fi
+
+	ICONFN="`echo ${ICON} | rev | cut -d/ -f1 | rev`"
+	DESKTOPFN="`echo ${DESKTOP} | rev | cut -d/ -f1 | rev`"
+
+	# Parse and Copy Desktop File
+	echo "Copying/Updating desktop file in ${TARGET}/applications/${DESKTOPFN}"
+
+	mkdir -p "${TARGET}/applications"
+	cat "${APPDIR}/${DESKTOPFN}" | sed -e "s\\^exec=.*$\\Exec=${APPIMAGE}\\gi" > "${TARGET}/applications/${DESKTOPFN}"
+
+	# Copy the Icon File
+	if [ ! -f "${TARGET}/icons/${ICONFN}" ]; then
+		echo "Copying ICON to ${TARGET}/icons/${ICONFN}"
+		mkdir -p "${TARGET}/icons"
+		cp "${APPDIR}/${ICONFN}" "${TARGET}/icons"
+	fi
+
+	# Update complete, so finish execution
+	exit
+fi
+
+EOF
+#
+# End of apprun-hooks scropt
+#
+
+echo "hook script installed in ${APPDIR}/apprun-hooks/${HOOKFILE}"
+exit 0
+


### PR DESCRIPTION
This plugin adds a hook script which is run before the main application in the AppImage.
The hook script intercepts an --install-desktop switch, and if provided, converts / parses the .desktop file and installs it into either the system folder or the user's .local folder.  It also copies the application icon across.

The resulting effect is "application.AppImage --install-desktop" puts the appropriate files in place so that the application appears in the linux start menu.

This has been tested on Ubuntu 22 and Ubuntu 20 with plasma desktop.
