### PR TITLE
fix `TEXTDOMAINDIR`

### DIFF
--- a/gettext/linuxdeploy-plugin-gettext.sh
+++ b/gettext/linuxdeploy-plugin-gettext.sh
@@ -39,5 +39,5 @@ mkdir -p "$appdir"/apprun-hooks
 cat > "$appdir"/apprun-hooks/linuxdeploy-plugin-gettext.sh <<\EOF
 #! /bin/bash
 
-export TEXTDOMAINDIR="$APPDIR"/usr/share/locale:"$TEXTDOMAINDIR"
+export TEXTDOMAINDIR="$APPDIR"/usr/share/locale
 EOF


### PR DESCRIPTION
better late than never. 

The variable can only contain one path, it does not accept multiple paths, see this test: 

<img width="1050" height="162" alt="image" src="https://github.com/user-attachments/assets/daa2cf1c-2034-47a3-afc1-41a41e9e5692" />

